### PR TITLE
(122) feat: create yarn scripts for hardhat

### DIFF
--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -20,5 +20,9 @@
     "ts-node": "^10.9.1",
     "typechain": "^8.3.2",
     "typescript": "^5.3.2"
+  },
+  "scripts": {
+    "test:local": "REPORT_GAS=true yarn hardhat test",
+    "deploy:local": "yarn hardhat run --network hardhat scripts/deploy.ts"
   }
 }


### PR DESCRIPTION
Now we can use the command `yarn test:local` to run all the tests in the /test folder, and with the command `yarn deploy:local` to run the deployment script with hardhat's local network.